### PR TITLE
Remove unnecessary shoving

### DIFF
--- a/src/agent/action/ExpandTo.java
+++ b/src/agent/action/ExpandTo.java
@@ -86,19 +86,26 @@ public class ExpandTo extends Action {
         // parent and its preferred progeny destination.
         DisplacementOption shortestOption = getShortestOption(target);
 
-        // Create a vacancy either at the parent or child site, depending on
-        // which had a shorter shoving path.
-        doShove(shortestOption);
+        // Check if the target and the origin are neighbors. If they are, we
+        // don't have to shove
+        Coordinate vacant;
+        if (shortestOption.occupied.equals(shortestOption.vacant)) {
+            vacant = shortestOption.vacant;
+        } else {
+            // Create a vacancy either at the parent or child site, depending on
+            // which had a shorter shoving path.
+            doShove(shortestOption);
 
-        // Now that the cells have been shoved toward the vacancy, the formerly
-        // occupied site is now vacant.
-        Coordinate newlyVacant = shortestOption.occupied;
+            // Clean up out-of-bounds cells.
+            shoveHelper.removeImaginary();
+
+            // Now that the cells have been shoved toward the vacancy, the formerly
+            // occupied site is now vacant.
+            vacant = shortestOption.occupied;
+        }
 
         // Place a cloned cell at the newly vacated position.
-        cloneToVacancy(newlyVacant);
-
-        // Clean up out-of-bounds cells.
-        shoveHelper.removeImaginary();
+        cloneToVacancy(vacant);
 
         // Highlight the parent and target locations.
         highlight(target, origin);


### PR DESCRIPTION
The `ExpandTo` action would always perform a shove action (and do the associated cleanup) even if nothing needed to be shoved. In particular, cleaning up the out of bounds cells took a lot of time. This adds a check to make sure we don't waste time.

[This simulation file](https://gist.github.com/cdgreenidge/fc10a189696975c3b23c) took 305 seconds to run on my machine; now it takes 14 seconds.

No new unit tests fail and the rendered output seems to be identical.
