### PR TITLE
Adds active sites to the injection process.

### DIFF
--- a/src/factory/processes/ProcessFactory.java
+++ b/src/factory/processes/ProcessFactory.java
@@ -179,7 +179,9 @@ public abstract class ProcessFactory {
     private static InjectionProcess injectionProcess(Element e, GeneralParameters p, BaseProcessArguments arguments) {
         Argument<Double> valueArg = DoubleArgumentFactory.instantiate(e, "value", p.getRandom());
         String layerId = XmlUtil.getString(e, "layer");
-        InjectionProcess process = new InjectionProcess(arguments, layerId, valueArg);
+        Geometry geom = arguments.getLayerManager().getCellLayer().getGeometry();
+        CoordinateSet activeSites = getActiveSites(e, geom, p);
+        InjectionProcess process = new InjectionProcess(arguments, valueArg, layerId, activeSites);
         return process;
     }
     protected static BaseProcessArguments makeProcessArguments(Element e,

--- a/src/processes/continuum/InjectionProcess.java
+++ b/src/processes/continuum/InjectionProcess.java
@@ -26,6 +26,8 @@ package processes.continuum;
 
 import control.arguments.Argument;
 import control.halt.HaltCondition;
+import control.identifiers.Coordinate;
+import geometry.set.CoordinateSet;
 import no.uib.cipr.matrix.DenseVector;
 import processes.*;
 import java.util.function.*;
@@ -38,21 +40,28 @@ public class InjectionProcess extends ContinuumProcess {
 
     private final Argument<Double> valueArg;
     private final String layerId;
+    private final CoordinateSet activeSites;
 
-    public InjectionProcess(BaseProcessArguments arguments, String layerId, Argument<Double> valueArg) {
+    public InjectionProcess(BaseProcessArguments arguments,
+                            Argument<Double> valueArg, String layerId,
+                            CoordinateSet activeSites) {
         super(arguments);
         this.valueArg = valueArg;
         this.layerId = layerId;
+        this.activeSites = activeSites;
     }
 
     @Override
     public void fire(StepState state) throws HaltCondition {
-        int n = getLayerManager().getCellLayer().getGeometry().getCanonicalSites().length;
-        DenseVector source = new DenseVector(n);
+        Coordinate[] canonicalSites = getLayerManager().getCellLayer()
+                .getGeometry().getCanonicalSites();
+        DenseVector source = new DenseVector(canonicalSites.length);
 
-        for (int i = 0; i < n; i++) {
+        for (int i = 0; i < canonicalSites.length; i++) {
             double value = valueArg.next();
-            source.set(i, value);
+            if (activeSites.contains(canonicalSites[i])) {
+                source.set(i, value);
+            }
         }
 
         getLayerManager().getContinuumLayer(layerId).getScheduler().inject(source);


### PR DESCRIPTION
This allows us to control where nutrient sources diffuse from like so:

![cellstate4 0e-14](https://cloud.githubusercontent.com/assets/3187354/8318255/366b5334-19d1-11e5-9305-72c61fd615f3.png)

We may still have to implement Dirichlet boundary conditions but at least this is a start.

No tests because ProcessFactory is so highly coupled (there's lines of code like `getLayerManager().getContinuumLayer(layerId).getScheduler().inject(source)`)
